### PR TITLE
Allow Artisan call not in console

### DIFF
--- a/src/TelescopeServiceProvider.php
+++ b/src/TelescopeServiceProvider.php
@@ -112,14 +112,17 @@ class TelescopeServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
-                Console\ClearCommand::class,
                 Console\InstallCommand::class,
-                Console\PauseCommand::class,
-                Console\PruneCommand::class,
                 Console\PublishCommand::class,
-                Console\ResumeCommand::class,
             ]);
         }
+        
+        $this->commands([
+                Console\ClearCommand::class,
+                Console\PauseCommand::class,
+                Console\PruneCommand::class,
+                Console\ResumeCommand::class,
+        ]);
     }
 
     /**


### PR DESCRIPTION
Allow Artisan some commands to run when not runningInConsole to be called via UI.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
